### PR TITLE
Update GWT V2 flood risk #1 building hover description to match action

### DIFF
--- a/src/app/gwt/locale/en.json
+++ b/src/app/gwt/locale/en.json
@@ -945,6 +945,9 @@
         "11a": "Building 11a<br/><strong>Action:</strong> Remove a hazard for $2<br/><strong>Action:</strong> Remove a hazard for $2",
         "13a": "Building 13a<br/><strong>Action:</strong> Gain 1 dollar per craftsman<br/><strong>Action:</strong> Move rancher 1 forward",
         "13b": "Building 13b<br/><strong>Action:</strong> Gain 2 dollars per upgraded station<br/><strong>Action:</strong> Take an exchange token"
+      },
+      "location": {
+        "FLOOD-RISK-1": "<br/><br/><strong>Risk Action:</strong> Discard a cattle card to move your certificate marker 1 space forward"
       }
     }
   }


### PR DESCRIPTION
### What

Updates the first flood risk building hover description to match the GWT V2 risk action

### Why

Currently, it still conveys the V1 description for the V2 action

### Notes

I only updated the `en.json` since I didn't see any localizations that had a "gwt2" dictionary of values